### PR TITLE
should disable auto associations explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ barrels.populate(['user'], function(err) {
 
       // Do your thing...
       done();
-    });
+    }, false);
   });
 ```
 


### PR DESCRIPTION
When required associations exist,  need pass false explicitly to disable auto association.
Could you consider make a change so that auto association is disabled by default when first parameter 
for populate method is an array.