### PR TITLE
Populate+improve options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Pass to the constructor the path to the folder containing your fixtures
 
 `Populate`'ing the test database involves three steps:
 
-* Removing any existing data from the collection corresponding to the fixture
+* Removing any existing data from the collection corresponding to the fixture (can be disabled
+  by passing `{purgeExistsData: false}` as the last parameter to `populate`)
 * Loading the fixture data into the test database
-* Automatically applying associations (can be disabled by passing `false` as
+* Automatically applying associations (can be disabled by passing `{autoAssociations: false}` as
   the last parameter to `populate`)
 
 `Populate` also accepts an array of names of collections to populate as

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ var _ = require('lodash');
  * @property {boolean} purgeExistsData - Indicate that .populate should removing any existing data from the collection corresponding to the fixture
  */
 var DEFAULT_POPULATE_OPTIONS = {
-	autoAssociations: true,
-	purgeExistsData: true
+  autoAssociations: true,
+  purgeExistsData: true
 };
 
 module.exports = Barrels;
@@ -31,31 +31,31 @@ module.exports = Barrels;
  * @param {string} sourceFolder defaults to <project root>/test/fixtures
  */
 function Barrels(sourceFolder) {
-	if (!(this instanceof Barrels))
-		return new Barrels(sourceFolder);
+  if (!(this instanceof Barrels))
+    return new Barrels(sourceFolder);
 
-	// Fixture objects loaded from the JSON files
-	this.data = {};
+  // Fixture objects loaded from the JSON files
+  this.data = {};
 
-	// Map fixture positions in JSON files to the real DB IDs
-	this.idMap = {};
+  // Map fixture positions in JSON files to the real DB IDs
+  this.idMap = {};
 
-	// The list of associations by model
-	this.associations = {};
+  // The list of associations by model
+  this.associations = {};
 
-	// Load the fixtures
-	sourceFolder = sourceFolder || process.cwd() + '/test/fixtures';
-	var files = fs.readdirSync(sourceFolder);
+  // Load the fixtures
+  sourceFolder = sourceFolder || process.cwd() + '/test/fixtures';
+  var files = fs.readdirSync(sourceFolder);
 
-	for (var i = 0; i < files.length; i++) {
-		if (['.json', '.js'].indexOf(path.extname(files[i]).toLowerCase()) !== -1) {
-			var modelName = path.basename(files[i]).split('.')[0].toLowerCase();
-			this.data[modelName] = require(path.join(sourceFolder, files[i]));
-		}
-	}
+  for (var i = 0; i < files.length; i++) {
+    if (['.json', '.js'].indexOf(path.extname(files[i]).toLowerCase()) !== -1) {
+      var modelName = path.basename(files[i]).split('.')[0].toLowerCase();
+      this.data[modelName] = require(path.join(sourceFolder, files[i]));
+    }
+  }
 
-	// The list of the fixtures model names
-	this.modelNames = Object.keys(this.data);
+  // The list of the fixtures model names
+  this.modelNames = Object.keys(this.data);
 }
 
 /**
@@ -63,56 +63,56 @@ function Barrels(sourceFolder) {
  * @param {function} done callback
  */
 Barrels.prototype.associate = function (collections, done) {
-	if (!_.isArray(collections)) {
-		done = collections;
-		collections = this.modelNames;
-	}
-	var that = this;
+  if (!_.isArray(collections)) {
+    done = collections;
+    collections = this.modelNames;
+  }
+  var that = this;
 
-	// Add associations whenever needed
-	async.each(collections, function (modelName, nextModel) {
-		var Model = sails.models[modelName];
-		if (Model) {
-			var fixtureObjects = _.cloneDeep(that.data[modelName]);
-			async.each(fixtureObjects, function (item, nextItem) {
-				// Item position in the file
-				var itemIndex = fixtureObjects.indexOf(item);
+  // Add associations whenever needed
+  async.each(collections, function (modelName, nextModel) {
+    var Model = sails.models[modelName];
+    if (Model) {
+      var fixtureObjects = _.cloneDeep(that.data[modelName]);
+      async.each(fixtureObjects, function (item, nextItem) {
+        // Item position in the file
+        var itemIndex = fixtureObjects.indexOf(item);
 
-				// Find and associate
-				Model.findOne(that.idMap[modelName][itemIndex]).exec(function (err, model) {
-					if (err)
-						return nextItem(err);
+        // Find and associate
+        Model.findOne(that.idMap[modelName][itemIndex]).exec(function (err, model) {
+          if (err)
+            return nextItem(err);
 
-					// Pick associations only
-					item = _.pick(item, Object.keys(that.associations[modelName]));
-					async.each(Object.keys(item), function (attr, nextAttr) {
-						var association = that.associations[modelName][attr];
-						// Required associations should have beed added earlier
-						if (association.required)
-							return nextAttr();
-						var joined = association[association.type];
+          // Pick associations only
+          item = _.pick(item, Object.keys(that.associations[modelName]));
+          async.each(Object.keys(item), function (attr, nextAttr) {
+            var association = that.associations[modelName][attr];
+            // Required associations should have beed added earlier
+            if (association.required)
+              return nextAttr();
+            var joined = association[association.type];
 
-						if (!_.isArray(item[attr]))
-							model[attr] = that.idMap[joined][item[attr] - 1];
-						else {
-							for (var j = 0; j < item[attr].length; j++) {
-								model[attr].add(that.idMap[joined][item[attr][j] - 1]);
-							}
-						}
+            if (!_.isArray(item[attr]))
+              model[attr] = that.idMap[joined][item[attr] - 1];
+            else {
+              for (var j = 0; j < item[attr].length; j++) {
+                model[attr].add(that.idMap[joined][item[attr][j] - 1]);
+              }
+            }
 
-						model.save(function (err) {
-							if (err)
-								return nextAttr(err);
+            model.save(function (err) {
+              if (err)
+                return nextAttr(err);
 
-							nextAttr();
-						});
-					}, nextItem);
-				});
-			}, nextModel);
-		} else {
-			nextModel();
-		}
-	}, done);
+              nextAttr();
+            });
+          }, nextItem);
+        });
+      }, nextModel);
+    } else {
+      nextModel();
+    }
+  }, done);
 };
 
 /**
@@ -122,116 +122,116 @@ Barrels.prototype.associate = function (collections, done) {
  * @param {DEFAULT_POPULATE_OPTIONS} _options_ - Options for populate fixtures
  */
 Barrels.prototype.populate = function (collections, done, _options_) {
-	if (!_.isArray(collections)) {
-		_options_ = done;
-		done = collections;
-		collections = this.modelNames;
-	}
-	else {
-		_.each(collections, function (collection) {
-			collection = collection.toLowerCase();
-		});
-	}
+  if (!_.isArray(collections)) {
+    _options_ = done;
+    done = collections;
+    collections = this.modelNames;
+  }
+  else {
+    _.each(collections, function (collection) {
+      collection = collection.toLowerCase();
+    });
+  }
 
-	var options = _.extend({}, DEFAULT_POPULATE_OPTIONS);
+  var options = _.extend({}, DEFAULT_POPULATE_OPTIONS);
 
-	// backward capability
-	if(_.isObject(_options_)){
-		_.extend(options, _options_);
-	}
-	else{
-		_.extend(options, {autoAssociations: !(_options_ === false)});
-	}
+  // backward capability
+  if (_.isObject(_options_)) {
+    _.extend(options, _options_);
+  }
+  else {
+    _.extend(options, {autoAssociations: !(_options_ === false)});
+  }
 
-	var that = this;
+  var that = this;
 
-	async.eachSeries(collections, _populate,
-		function (err) {
-			if (err)
-				return done(err);
+  async.eachSeries(collections, _populate,
+    function (err) {
+      if (err)
+        return done(err);
 
-			// Create associations if requested
-			if (options.autoAssociations)
-				return that.associate(collections, done);
+      // Create associations if requested
+      if (options.autoAssociations)
+        return that.associate(collections, done);
 
-			done();
-		});
+      done();
+    });
 
-	/**
-	 * Populate each table / collection
-	 * TODO Looks that some refactoring could be doing.
-	 * @param modelName
-	 * @param nextModel
-	 */
-	function _populate(modelName, nextModel) {
-		var Model = sails.models[modelName];
-		if (Model) {
-			if (options.purgeExistsData) {
-				// Cleanup existing data in the table / collection
-				Model.destroy().exec(insertFixtures);
-			} else {
-				sails.log.warn('barrels:populate', 'Be sure that keeping records it\'s really that you want');
-				insertFixtures();
-			}
-		} else {
-			nextModel();
-		}
+  /**
+   * Populate each table / collection
+   * TODO Looks that some refactoring could be doing.
+   * @param modelName
+   * @param nextModel
+   */
+  function _populate(modelName, nextModel) {
+    var Model = sails.models[modelName];
+    if (Model) {
+      if (options.purgeExistsData) {
+        // Cleanup existing data in the table / collection
+        Model.destroy().exec(insertFixtures);
+      } else {
+        sails.log.warn('barrels:populate', 'Be sure that keeping records it\'s really that you want');
+        insertFixtures();
+      }
+    } else {
+      nextModel();
+    }
 
-		function insertFixtures(err) {
-			if (err)
-				return nextModel(err);
+    function insertFixtures(err) {
+      if (err)
+        return nextModel(err);
 
-			// Save model's association information
-			that.associations[modelName] = {};
-			for (var i = 0; i < Model.associations.length; i++) {
-				var alias = Model.associations[i].alias;
-				that.associations[modelName][alias] = Model.associations[i];
-				that.associations[modelName][alias].required = !!(Model._validator.validations[alias].required);
-			}
+      // Save model's association information
+      that.associations[modelName] = {};
+      for (var i = 0; i < Model.associations.length; i++) {
+        var alias = Model.associations[i].alias;
+        that.associations[modelName][alias] = Model.associations[i];
+        that.associations[modelName][alias].required = !!(Model._validator.validations[alias].required);
+      }
 
-			// Insert all the fixture items
-			that.idMap[modelName] = [];
-			var fixtureObjects = _.cloneDeep(that.data[modelName]);
-			async.each(fixtureObjects, function (item, nextItem) {
-				// Item position in the file
-				var itemIndex = fixtureObjects.indexOf(item);
+      // Insert all the fixture items
+      that.idMap[modelName] = [];
+      var fixtureObjects = _.cloneDeep(that.data[modelName]);
+      async.each(fixtureObjects, function (item, nextItem) {
+        // Item position in the file
+        var itemIndex = fixtureObjects.indexOf(item);
 
-				for (var alias in that.associations[modelName]) {
-					if (that.associations[modelName][alias].required) {
-						// With required associations present, the associated fixtures
-						// must be already loaded, so we can map the ids
-						var collectionName = that.associations[modelName][alias].collection; // many-to-many
-						var associatedModelName = that.associations[modelName][alias].model; // one-to-many
+        for (var alias in that.associations[modelName]) {
+          if (that.associations[modelName][alias].required) {
+            // With required associations present, the associated fixtures
+            // must be already loaded, so we can map the ids
+            var collectionName = that.associations[modelName][alias].collection; // many-to-many
+            var associatedModelName = that.associations[modelName][alias].model; // one-to-many
 
-						if ((_.isArray(item[alias])) && (collectionName)) {
-							if (!that.idMap[collectionName])
-								return nextItem(new Error('Please provide a loading order acceptable for required associations'));
-							for (var i = 0; i < item[alias].length; i++) {
-								item[alias][i] = that.idMap[collectionName][item[alias][i] - 1];
-							}
-						} else if (associatedModelName) {
-							if (!that.idMap[associatedModelName])
-								return nextItem(new Error('Please provide a loading order acceptable for required associations'));
-							item[alias] = that.idMap[associatedModelName][item[alias] - 1];
-						}
-					} else if (options.autoAssociations) {
-						// The order is not important, so we can strip
-						// associations data and associate later
-						item = _.omit(item, alias);
-					}
-				}
+            if ((_.isArray(item[alias])) && (collectionName)) {
+              if (!that.idMap[collectionName])
+                return nextItem(new Error('Please provide a loading order acceptable for required associations'));
+              for (var i = 0; i < item[alias].length; i++) {
+                item[alias][i] = that.idMap[collectionName][item[alias][i] - 1];
+              }
+            } else if (associatedModelName) {
+              if (!that.idMap[associatedModelName])
+                return nextItem(new Error('Please provide a loading order acceptable for required associations'));
+              item[alias] = that.idMap[associatedModelName][item[alias] - 1];
+            }
+          } else if (options.autoAssociations) {
+            // The order is not important, so we can strip
+            // associations data and associate later
+            item = _.omit(item, alias);
+          }
+        }
 
-				// Insert
-				Model.create(item).exec(function (err, model) {
-					if (err)
-						return nextItem(err);
+        // Insert
+        Model.create(item).exec(function (err, model) {
+          if (err)
+            return nextItem(err);
 
-					// Primary key mapping
-					that.idMap[modelName][itemIndex] = model[Model.primaryKey];
+          // Primary key mapping
+          that.idMap[modelName][itemIndex] = model[Model.primaryKey];
 
-					nextItem();
-				});
-			}, nextModel);
-		}
-	}
+          nextItem();
+        });
+      }, nextModel);
+    }
+  }
 };

--- a/index.js
+++ b/index.js
@@ -31,88 +31,88 @@ module.exports = Barrels;
  * @param {string} sourceFolder defaults to <project root>/test/fixtures
  */
 function Barrels(sourceFolder) {
-  if (!(this instanceof Barrels))
-    return new Barrels(sourceFolder);
+	if (!(this instanceof Barrels))
+		return new Barrels(sourceFolder);
 
-  // Fixture objects loaded from the JSON files
-  this.data = {};
+	// Fixture objects loaded from the JSON files
+	this.data = {};
 
-  // Map fixture positions in JSON files to the real DB IDs
-  this.idMap = {};
+	// Map fixture positions in JSON files to the real DB IDs
+	this.idMap = {};
 
-  // The list of associations by model
-  this.associations = {};
+	// The list of associations by model
+	this.associations = {};
 
-  // Load the fixtures
-  sourceFolder = sourceFolder || process.cwd() + '/test/fixtures';
-  var files = fs.readdirSync(sourceFolder);
+	// Load the fixtures
+	sourceFolder = sourceFolder || process.cwd() + '/test/fixtures';
+	var files = fs.readdirSync(sourceFolder);
 
-  for (var i = 0; i < files.length; i++) {
-    if (['.json', '.js'].indexOf(path.extname(files[i]).toLowerCase()) !== -1) {
-      var modelName = path.basename(files[i]).split('.')[0].toLowerCase();
-      this.data[modelName] = require(path.join(sourceFolder, files[i]));
-    }
-  }
+	for (var i = 0; i < files.length; i++) {
+		if (['.json', '.js'].indexOf(path.extname(files[i]).toLowerCase()) !== -1) {
+			var modelName = path.basename(files[i]).split('.')[0].toLowerCase();
+			this.data[modelName] = require(path.join(sourceFolder, files[i]));
+		}
+	}
 
-  // The list of the fixtures model names
-  this.modelNames = Object.keys(this.data);
+	// The list of the fixtures model names
+	this.modelNames = Object.keys(this.data);
 }
 
 /**
  * Add associations
  * @param {function} done callback
  */
-Barrels.prototype.associate = function(collections, done) {
-  if (!_.isArray(collections)) {
-    done = collections;
-    collections = this.modelNames;
-  }
-  var that = this;
+Barrels.prototype.associate = function (collections, done) {
+	if (!_.isArray(collections)) {
+		done = collections;
+		collections = this.modelNames;
+	}
+	var that = this;
 
-  // Add associations whenever needed
-  async.each(collections, function(modelName, nextModel) {
-    var Model = sails.models[modelName];
-    if (Model) {
-      var fixtureObjects = _.cloneDeep(that.data[modelName]);
-      async.each(fixtureObjects, function(item, nextItem) {
-        // Item position in the file
-        var itemIndex = fixtureObjects.indexOf(item);
+	// Add associations whenever needed
+	async.each(collections, function (modelName, nextModel) {
+		var Model = sails.models[modelName];
+		if (Model) {
+			var fixtureObjects = _.cloneDeep(that.data[modelName]);
+			async.each(fixtureObjects, function (item, nextItem) {
+				// Item position in the file
+				var itemIndex = fixtureObjects.indexOf(item);
 
-        // Find and associate
-        Model.findOne(that.idMap[modelName][itemIndex]).exec(function(err, model) {
-          if (err)
-            return nextItem(err);
+				// Find and associate
+				Model.findOne(that.idMap[modelName][itemIndex]).exec(function (err, model) {
+					if (err)
+						return nextItem(err);
 
-          // Pick associations only
-          item = _.pick(item, Object.keys(that.associations[modelName]));
-          async.each(Object.keys(item), function(attr, nextAttr) {
-            var association = that.associations[modelName][attr];
-            // Required associations should have beed added earlier
-            if (association.required)
-              return nextAttr();
-            var joined = association[association.type];
+					// Pick associations only
+					item = _.pick(item, Object.keys(that.associations[modelName]));
+					async.each(Object.keys(item), function (attr, nextAttr) {
+						var association = that.associations[modelName][attr];
+						// Required associations should have beed added earlier
+						if (association.required)
+							return nextAttr();
+						var joined = association[association.type];
 
-            if (!_.isArray(item[attr]))
-              model[attr] = that.idMap[joined][item[attr]-1];
-            else {
-              for (var j = 0; j < item[attr].length; j++) {
-                model[attr].add(that.idMap[joined][item[attr][j]-1]);
-              }
-            }
+						if (!_.isArray(item[attr]))
+							model[attr] = that.idMap[joined][item[attr] - 1];
+						else {
+							for (var j = 0; j < item[attr].length; j++) {
+								model[attr].add(that.idMap[joined][item[attr][j] - 1]);
+							}
+						}
 
-            model.save(function(err) {
-              if (err)
-                return nextAttr(err);
+						model.save(function (err) {
+							if (err)
+								return nextAttr(err);
 
-              nextAttr();
-            });
-          }, nextItem);
-        });
-      }, nextModel);
-    } else {
-      nextModel();
-    }
-  }, done);
+							nextAttr();
+						});
+					}, nextItem);
+				});
+			}, nextModel);
+		} else {
+			nextModel();
+		}
+	}, done);
 };
 
 /**
@@ -121,103 +121,111 @@ Barrels.prototype.associate = function(collections, done) {
  * @param {function} done callback
  * @param {DEFAULT_POPULATE_OPTIONS} _options_ - Options for populate fixtures
  */
-Barrels.prototype.populate = function(collections, done, _options_) {
-  if (!_.isArray(collections)) {
-    _options_ = done;
-    done = collections;
-    collections = this.modelNames;
-  }
-  else {
-    _.each(collections, function(collection) {
-      collection = collection.toLowerCase();
-    });
-  }
+Barrels.prototype.populate = function (collections, done, _options_) {
+	if (!_.isArray(collections)) {
+		_options_ = done;
+		done = collections;
+		collections = this.modelNames;
+	}
+	else {
+		_.each(collections, function (collection) {
+			collection = collection.toLowerCase();
+		});
+	}
 
 	// backward capability
 	var options = _.isObject(options) ?
 		_.extend({}, DEFAULT_POPULATE_OPTIONS, _options_)
 		: _.extend({}, DEFAULT_POPULATE_OPTIONS, {autoAssociations: !(_options_ === false)});
 
-  var that = this;
+	var that = this;
 
-  // Populate each table / collection
-  async.each(collections, function(modelName, nextModel) {
-    var Model = sails.models[modelName];
-    if (Model) {
-	    if(options.purgeExistsData){
-        // Cleanup existing data in the table / collection
-        Model.destroy().exec(insertFixtures);
-	    }else{
-		    insertFixtures();
-	    }
-    } else {
-      nextModel();
-    }
+	async.each(collections, _populate,
+		function (err) {
+			if (err)
+				return done(err);
 
-	  function insertFixtures(err) {
-		  if (err)
-			  return nextModel(err);
+			// Create associations if requested
+			if (options.autoAssociations)
+				return that.associate(collections, done);
 
-		  // Save model's association information
-		  that.associations[modelName] = {};
-		  for (var i = 0; i < Model.associations.length; i++) {
-			  var alias = Model.associations[i].alias;
-			  that.associations[modelName][alias] = Model.associations[i];
-			  that.associations[modelName][alias].required = !!(Model._validator.validations[alias].required);
-		  }
+			done();
+		});
 
-		  // Insert all the fixture items
-		  that.idMap[modelName] = [];
-		  var fixtureObjects = _.cloneDeep(that.data[modelName]);
-		  async.each(fixtureObjects, function(item, nextItem) {
-			  // Item position in the file
-			  var itemIndex = fixtureObjects.indexOf(item);
+	/**
+	 * Populate each table / collection
+	 * TODO Looks that some refactoring could be doing.
+	 * @param modelName
+	 * @param nextModel
+	 */
+	function _populate(modelName, nextModel) {
+		var Model = sails.models[modelName];
+		if (Model) {
+			if (options.purgeExistsData) {
+				// Cleanup existing data in the table / collection
+				Model.destroy().exec(insertFixtures);
+			} else {
+				insertFixtures();
+			}
+		} else {
+			nextModel();
+		}
 
-			  for (var alias in that.associations[modelName]) {
-				  if (that.associations[modelName][alias].required) {
-					  // With required associations present, the associated fixtures
-					  // must be already loaded, so we can map the ids
-					  var collectionName = that.associations[modelName][alias].collection; // many-to-many
-					  var associatedModelName = that.associations[modelName][alias].model; // one-to-many
+		function insertFixtures(err) {
+			if (err)
+				return nextModel(err);
 
-					  if ((_.isArray(item[alias]))&&(collectionName)) {
-						  if (!that.idMap[collectionName])
-							  return nextItem(new Error('Please provide a loading order acceptable for required associations'));
-						  for (var i = 0; i < item[alias].length; i++) {
-							  item[alias][i] = that.idMap[collectionName][item[alias][i] - 1];
-						  }
-					  } else if (associatedModelName) {
-						  if (!that.idMap[associatedModelName])
-							  return nextItem(new Error('Please provide a loading order acceptable for required associations'));
-						  item[alias] = that.idMap[associatedModelName][item[alias] - 1];
-					  }
-				  } else if (options.autoAssociations) {
-					  // The order is not important, so we can strip
-					  // associations data and associate later
-					  item = _.omit(item, alias);
-				  }
-			  }
+			// Save model's association information
+			that.associations[modelName] = {};
+			for (var i = 0; i < Model.associations.length; i++) {
+				var alias = Model.associations[i].alias;
+				that.associations[modelName][alias] = Model.associations[i];
+				that.associations[modelName][alias].required = !!(Model._validator.validations[alias].required);
+			}
 
-			  // Insert
-			  Model.create(item).exec(function(err, model) {
-				  if (err)
-					  return nextItem(err);
+			// Insert all the fixture items
+			that.idMap[modelName] = [];
+			var fixtureObjects = _.cloneDeep(that.data[modelName]);
+			async.each(fixtureObjects, function (item, nextItem) {
+				// Item position in the file
+				var itemIndex = fixtureObjects.indexOf(item);
 
-				  // Primary key mapping
-				  that.idMap[modelName][itemIndex] = model[Model.primaryKey];
+				for (var alias in that.associations[modelName]) {
+					if (that.associations[modelName][alias].required) {
+						// With required associations present, the associated fixtures
+						// must be already loaded, so we can map the ids
+						var collectionName = that.associations[modelName][alias].collection; // many-to-many
+						var associatedModelName = that.associations[modelName][alias].model; // one-to-many
 
-				  nextItem();
-			  });
-		  }, nextModel);
-	  }
-  }, function(err) {
-    if (err)
-      return done(err);
+						if ((_.isArray(item[alias])) && (collectionName)) {
+							if (!that.idMap[collectionName])
+								return nextItem(new Error('Please provide a loading order acceptable for required associations'));
+							for (var i = 0; i < item[alias].length; i++) {
+								item[alias][i] = that.idMap[collectionName][item[alias][i] - 1];
+							}
+						} else if (associatedModelName) {
+							if (!that.idMap[associatedModelName])
+								return nextItem(new Error('Please provide a loading order acceptable for required associations'));
+							item[alias] = that.idMap[associatedModelName][item[alias] - 1];
+						}
+					} else if (options.autoAssociations) {
+						// The order is not important, so we can strip
+						// associations data and associate later
+						item = _.omit(item, alias);
+					}
+				}
 
-    // Create associations if requested
-    if (options.autoAssociations)
-      return that.associate(collections, done);
+				// Insert
+				Model.create(item).exec(function (err, model) {
+					if (err)
+						return nextItem(err);
 
-    done();
-  });
+					// Primary key mapping
+					that.idMap[modelName][itemIndex] = model[Model.primaryKey];
+
+					nextItem();
+				});
+			}, nextModel);
+		}
+	}
 };

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
 
 	var that = this;
 
-	async.each(collections, _populate,
+	async.eachSeries(collections, _populate,
 		function (err) {
 			if (err)
 				return done(err);

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function Barrels(sourceFolder) {
  * Add associations
  * @param {function} done callback
  */
-Barrels.prototype.associate = function (collections, done) {
+Barrels.prototype.associate = function(collections, done) {
   if (!_.isArray(collections)) {
     done = collections;
     collections = this.modelNames;
@@ -70,22 +70,22 @@ Barrels.prototype.associate = function (collections, done) {
   var that = this;
 
   // Add associations whenever needed
-  async.each(collections, function (modelName, nextModel) {
+  async.each(collections, function(modelName, nextModel) {
     var Model = sails.models[modelName];
     if (Model) {
       var fixtureObjects = _.cloneDeep(that.data[modelName]);
-      async.each(fixtureObjects, function (item, nextItem) {
+      async.each(fixtureObjects, function(item, nextItem) {
         // Item position in the file
         var itemIndex = fixtureObjects.indexOf(item);
 
         // Find and associate
-        Model.findOne(that.idMap[modelName][itemIndex]).exec(function (err, model) {
+        Model.findOne(that.idMap[modelName][itemIndex]).exec(function(err, model) {
           if (err)
             return nextItem(err);
 
           // Pick associations only
           item = _.pick(item, Object.keys(that.associations[modelName]));
-          async.each(Object.keys(item), function (attr, nextAttr) {
+          async.each(Object.keys(item), function(attr, nextAttr) {
             var association = that.associations[modelName][attr];
             // Required associations should have beed added earlier
             if (association.required)
@@ -100,7 +100,7 @@ Barrels.prototype.associate = function (collections, done) {
               }
             }
 
-            model.save(function (err) {
+            model.save(function(err) {
               if (err)
                 return nextAttr(err);
 
@@ -121,14 +121,14 @@ Barrels.prototype.associate = function (collections, done) {
  * @param {function} done callback
  * @param {DEFAULT_POPULATE_OPTIONS} _options_ - Options for populate fixtures
  */
-Barrels.prototype.populate = function (collections, done, _options_) {
+Barrels.prototype.populate = function(collections, done, _options_) {
   if (!_.isArray(collections)) {
     _options_ = done;
     done = collections;
     collections = this.modelNames;
   }
   else {
-    _.each(collections, function (collection) {
+    _.each(collections, function(collection) {
       collection = collection.toLowerCase();
     });
   }
@@ -146,7 +146,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
   var that = this;
 
   async.eachSeries(collections, _populate,
-    function (err) {
+    function(err) {
       if (err)
         return done(err);
 
@@ -192,7 +192,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
       // Insert all the fixture items
       that.idMap[modelName] = [];
       var fixtureObjects = _.cloneDeep(that.data[modelName]);
-      async.each(fixtureObjects, function (item, nextItem) {
+      async.each(fixtureObjects, function(item, nextItem) {
         // Item position in the file
         var itemIndex = fixtureObjects.indexOf(item);
 
@@ -222,7 +222,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
         }
 
         // Insert
-        Model.create(item).exec(function (err, model) {
+        Model.create(item).exec(function(err, model) {
           if (err)
             return nextItem(err);
 

--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
 				// Cleanup existing data in the table / collection
 				Model.destroy().exec(insertFixtures);
 			} else {
+				sails.log.warn('barrels:populate', 'Be sure that keeping records it\'s really that you want');
 				insertFixtures();
 			}
 		} else {

--- a/index.js
+++ b/index.js
@@ -133,10 +133,15 @@ Barrels.prototype.populate = function (collections, done, _options_) {
 		});
 	}
 
+	var options = _.extend({}, DEFAULT_POPULATE_OPTIONS);
+
 	// backward capability
-	var options = _.isObject(options) ?
-		_.extend({}, DEFAULT_POPULATE_OPTIONS, _options_)
-		: _.extend({}, DEFAULT_POPULATE_OPTIONS, {autoAssociations: !(_options_ === false)});
+	if(_.isObject(_options_)){
+		_.extend(options, _options_);
+	}
+	else{
+		_.extend(options, {autoAssociations: !(_options_ === false)});
+	}
 
 	var that = this;
 


### PR DESCRIPTION
## Explanation:
Given we have `model::sails.model` that, for some reason, have lifecycle callback:
```javascript
beforeDestroy: function(condition, next){
  next(new Error(403, 'Delete forbidden'));
}
```
When trying to populate fixtures into `Model` throws exception.
## Solution:
Give ability to preserve exists data via passing parameter to `.populate`. Aside: wrap passed options to object, with backward capability.

> I'm so sorry about 'spaces'.