### PR TITLE
Load collection in series to accommodate required associations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ Barrels.prototype.populate = function(collections, done, autoAssociations) {
   var that = this;
 
   // Populate each table / collection
-  async.each(collections, function(modelName, nextModel) {
+  async.eachSeries(collections, function(modelName, nextModel) {
     var Model = sails.models[modelName];
     if (Model) {
       // Cleanup existing data in the table / collection


### PR DESCRIPTION
When using some Waterline adapters the fixtures are populated out of order even if a load order is provided due to the use of `async.each`, resulting in error messages such as

```
Invalid attributes sent to Passport:
 • user
   • "required" validation rule failed for input: null
```

This fixes the issue by switching to `async.eachSeries`. See [#31](https://github.com/bredikhin/barrels/issues/31#issuecomment-167754588) for further discussion.
