### PR TITLE
Allows for multiple sets of fixtures per tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function Barrels(sourceFolder) {
   this.associations = {};
 
   // Load the fixtures
-    if (sourceFolder) {
+  if (sourceFolder) {
     sourceFolder = process.cwd() + '/' + sourceFolder;
   } else {
     sourceFolder = process.cwd() + '/test/fixtures';

--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ function Barrels(sourceFolder) {
   this.associations = {};
 
   // Load the fixtures
-  sourceFolder = sourceFolder || process.cwd() + '/test/fixtures';
+    if (sourceFolder) {
+    sourceFolder = process.cwd() + '/' + sourceFolder;
+  } else {
+    sourceFolder = process.cwd() + '/test/fixtures';
+  }
   var files = fs.readdirSync(sourceFolder);
 
   for (var i = 0; i < files.length; i++) {


### PR DESCRIPTION
This allows for the sourceFolder to work off of the current working directory so that if you specify it, it will look in the cwd for that sourceFolder, instead of looking at the absolute path of sourceFolder.  This way you can instantiate new barrels similar to this:

barrels = new Barrels('./test/fixtures/SomeSpecificTest');

Rather than having to specify the absolute path which can change depending on whether you are running the tests in one environment or another (ie, developer vs CI).

