### PR TITLE
Fixes the license value in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,5 @@
       "email": "marnusw@gmail.com"
     }
   ],
-  "license": {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
The license value in the package.json should be a valid SPDX as documented on (https://docs.npmjs.com/files/package.json#license). This commit fixes it.