### PR TITLE
made compatible with sails@^1.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ Barrels.prototype.populate = function(collections, done, autoAssociations) {
     var Model = sails.models[modelName];
     if (Model) {
       // Cleanup existing data in the table / collection
-      Model.destroy().exec(function(err) {
+      Model.destroy({}).exec(function(err) {
         if (err)
           return nextModel(err);
 
@@ -176,7 +176,7 @@ Barrels.prototype.populate = function(collections, done, autoAssociations) {
           }
 
           // Insert
-          Model.create(item).exec(function(err, model) {
+            Model.create(item).fetch().exec(function(err, model) {
             if (err)
               return nextItem(err);
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     {
       "name": "Marnus Weststrate",
       "email": "marnusw@gmail.com"
+    },
+    {
+      "name": "Kanakala Sumanth",
+      "email": "kanakala.sumanth@gmail.com"
     }
   ],
   "license": "MIT"


### PR DESCRIPTION
Dear Ruslan, 
In Sails, `.create()` no longer sends back the created record. I made changes required to support for the 1.0.1 version. You can see it [here](https://sailsjs.com/documentation/upgrading/to-v-1-0#?changes-to-create-createeach-update-and-destroy-results).
Please review the changes and merge the code if you considered it as valid.

Thanks.